### PR TITLE
Hyperrectangle

### DIFF
--- a/test/external/fuzz_shapetracker.py
+++ b/test/external/fuzz_shapetracker.py
@@ -2,60 +2,60 @@ import random
 from tinygrad.helpers import DEBUG, getenv
 from test.unit.test_shapetracker import CheckingShapeTracker
 
-def do_permute(st):
+def do_permute(st, verbose=True):
   perm = list(range(0, len(st.shape)))
   random.shuffle(perm)
   perm = tuple(perm)
-  if DEBUG >= 1: print("st.permute(", perm, ")")
+  if DEBUG >=1 and verbose: print("st.permute(", perm, ")")
   st.permute(perm)
 
-def do_pad(st):
+def do_pad(st, verbose=True):
   c = random.randint(0, len(st.shape)-1)
   pad = tuple((random.randint(0,2), random.randint(0,2)) if i==c else (0,0) for i in range(len(st.shape)))
-  if DEBUG >= 1: print("st.pad(", pad, ")")
+  if DEBUG >=1 and verbose: print("st.pad(", pad, ")")
   st.pad(pad)
 
-def do_reshape_split_one(st):
+def do_reshape_split_one(st, verbose=True):
   c = random.randint(0, len(st.shape)-1)
   poss = [n for n in [1,2,3,4,5] if st.shape[c]%n == 0]
   spl = random.choice(poss)
   shp = st.shape[0:c] + (st.shape[c]//spl, spl) + st.shape[c+1:]
-  if DEBUG >= 1: print("st.reshape(", shp, ")")
+  if DEBUG >=1 and verbose: print("st.reshape(", shp, ")")
   st.reshape(shp)
 
-def do_reshape_combine_two(st):
+def do_reshape_combine_two(st, verbose=True):
   if len(st.shape) < 2: return
   c = random.randint(0, len(st.shape)-2)
   shp = st.shape[:c] + (st.shape[c] * st.shape[c+1], ) + st.shape[c+2:]
-  if DEBUG >= 1: print("st.reshape(", shp, ")")
+  if DEBUG >=1 and verbose: print("st.reshape(", shp, ")")
   st.reshape(shp)
 
-def do_shrink(st):
+def do_shrink(st, verbose=True):
   c = random.randint(0, len(st.shape)-1)
   while 1:
     shrink = tuple((random.randint(0,s), random.randint(0,s)) if i == c else (0,s) for i,s in enumerate(st.shape))
     if all(x<y for (x,y) in shrink): break
-  if DEBUG >= 1: print("st.shrink(", shrink, ")")
+  if DEBUG >=1 and verbose: print("st.shrink(", shrink, ")")
   st.shrink(shrink)
 
-def do_stride(st):
+def do_stride(st, verbose=True):
   c = random.randint(0, len(st.shape)-1)
   stride = tuple(random.choice([-2,-1,2]) if i==c else 1 for i in range(len(st.shape)))
-  if DEBUG >= 1: print("st.stride(", stride, ")")
+  if DEBUG >=1 and verbose: print("st.stride(", stride, ")")
   st.stride(stride)
 
-def do_flip(st):
+def do_flip(st, verbose=True):
   c = random.randint(0, len(st.shape)-1)
   stride = tuple(-1 if i==c else 1 for i in range(len(st.shape)))
-  if DEBUG >= 1: print("st.stride(", stride, ")")
+  if DEBUG >=1 and verbose: print("st.stride(", stride, ")")
   st.stride(stride)
 
-def do_expand(st):
+def do_expand(st, verbose=True):
   c = [i for i,s in enumerate(st.shape) if s==1]
   if len(c) == 0: return
   c = random.choice(c)
   expand = tuple(random.choice([2,3,4]) if i==c else s for i,s in enumerate(st.shape))
-  if DEBUG >= 1: print("st.expand(", expand, ")")
+  if DEBUG >=1 and verbose: print("st.expand(", expand, ")")
   st.expand(expand)
 
 shapetracker_ops = [do_permute, do_pad, do_shrink, do_reshape_split_one, do_reshape_combine_two, do_stride, do_expand]

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
       # compare results
       eq = st_equal(st1, st2)
       eqs = sts1 == sts2
-      eqc = stc1 == stc2
+      eqc = stc1.equals(stc2)
       # update stats
       if getenv("CHECK_NEQ") and eq and not eqs: same_but_neq += 1
       if eq and not eqc: same_but_neq_cannon += 1

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
       if getenv("CHECK_NEQ") and eq and not eqs: same_but_neq += 1
       if eq and not eqc: same_but_neq_cannon += 1
       # print stuff
-      filterout = False if DEBUG >=1 and getenv("ONLY_NEQ", 0)==0 else not (eq and not eqs)
+      filterout = False if DEBUG >=1 and getenv("ONLY_NEQ", 0)==0 else not (eq and not eqc)
       if not filterout:
         if eq and not eqc:
           if DEBUG >=2 and getenv("VERBOSE", 1) == 2:

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
       # compare results
       eq = st_equal(st1, st2)
       eqs = sts1 == sts2
-      eqc = stc1.equals(stc2)
+      eqc = stc1 == stc2
       # update stats
       if getenv("CHECK_NEQ") and eq and not eqs: same_but_neq += 1
       if eq and not eqc: same_but_neq_cannon += 1

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -2,47 +2,109 @@ import random
 from typing import Tuple
 from tqdm import trange
 from tinygrad.helpers import getenv, DEBUG, colored
-from tinygrad.shape.shapetracker import ShapeTracker
+from tinygrad.shape.shapetracker import ShapeTracker, _project_view
 from test.external.fuzz_shapetracker import shapetracker_ops
 from test.external.fuzz_shapetracker import do_permute, do_reshape_split_one, do_reshape_combine_two, do_flip, do_pad
 from test.unit.test_shapetracker_math import st_equal, MultiShapeTracker
 
-def fuzz_plus() -> Tuple[ShapeTracker, ShapeTracker]:
-  m = MultiShapeTracker([ShapeTracker.from_shape((random.randint(1, 10), random.randint(1, 10), random.randint(1, 10)))])
-  for _ in range(4): random.choice(shapetracker_ops)(m)
+def fuzz_plus(verbose=True) -> Tuple[ShapeTracker, ShapeTracker]:
+  start = ShapeTracker.from_shape((random.randint(1, 10), random.randint(1, 10), random.randint(1, 10)))
+  m = MultiShapeTracker([start])
+  if DEBUG >=2 and getenv("VERBOSE", 1) == 2 and verbose: print(f"{start=}")
+  for _ in range(4): random.choice(shapetracker_ops)(m, verbose)
   backup = m.sts[0]
+  if DEBUG >=2 and getenv("VERBOSE", 1) == 2 and verbose: print(f"{backup=}")
   m.sts.append(ShapeTracker.from_shape(m.sts[0].shape))
-  for _ in range(4): random.choice(shapetracker_ops)(m)
+  for _ in range(4): random.choice(shapetracker_ops)(m, verbose)
   st_sum = backup + m.sts[1]
   return m.sts[0], st_sum
 
 # shrink and expand aren't invertible, and stride is only invertible in the flip case
 invertible_shapetracker_ops = [do_permute, do_reshape_split_one, do_reshape_combine_two, do_flip, do_pad]
 
-def fuzz_invert() -> Tuple[ShapeTracker, ShapeTracker]:
+def fuzz_invert(verbose=True) -> Tuple[ShapeTracker, ShapeTracker]:
   start = ShapeTracker.from_shape((random.randint(1, 10), random.randint(1, 10), random.randint(1, 10)))
   m = MultiShapeTracker([start])
-  for _ in range(8): random.choice(invertible_shapetracker_ops)(m)
+  if DEBUG >=2 and getenv("VERBOSE", 1) == 2 and verbose: print(f"{start=}")
+  for _ in range(8): random.choice(invertible_shapetracker_ops)(m, verbose)
   inv = m.sts[0].invert(start.shape)
   st_sum = (m.sts[0] + inv) if inv else None
   return start, st_sum
 
+def _display_extra_info(exp: ShapeTracker, got: ShapeTracker):
+  if len(exp.views) >= 2:
+    print()
+    exp = ShapeTracker(exp.views[-2:])
+    expv2, expv1 = exp.views
+    print(f"{expv1.shape=}")
+    print(f"{expv1.strides=}")
+    print(f"{expv1.offset=}")
+    print(f"{expv1.mask=}")
+    print(f"{expv1.contiguous=}")
+    print()
+    orig, _, pstrides = _project_view(expv2, expv1)
+    print(f"expv1.origin={tuple(orig)}")
+    print(f"expv1.pstrides={tuple(pstrides)}")
+    print(f"expv1.real_pstrides={exp.real_strides()}")
+  if len(got.views) >= 2:
+    print()
+    got = ShapeTracker(got.views[-2:])
+    gotv2, gotv1 = got.views
+    print(f"{gotv1.shape=}")
+    print(f"{gotv1.strides=}")
+    print(f"{gotv1.offset=}")
+    print(f"{gotv1.mask=}")
+    print(f"{gotv1.contiguous=}")
+    print()
+    orig, _, pstrides = _project_view(gotv2, gotv1)
+    print(f"gotv1.origin={tuple(orig)}")
+    print(f"gotv1.pstrides={tuple(pstrides)}")
+    print(f"gotv1.real_pstrides={got.real_strides()}")
+
 if __name__ == "__main__":
   if seed:=getenv("SEED"): random.seed(seed)
+  verbose = False if DEBUG >=1 and getenv("ONLY_NEQ", 0) ==1 else getenv("VERBOSE", 1) >=1
   total = getenv("CNT", 1000)
   for fuzz in [globals()[f'fuzz_{x}'] for x in getenv("FUZZ", "invert,plus").split(",")]:
-    same_but_neq = 0
+    same_but_neq = same_but_neq_cannon = 0
     for _ in trange(total, desc=f"{fuzz}"):
-      st1, st2 = fuzz()
+      # fuzz shapetrackers
+      st1, st2 = fuzz(verbose)
+      sts1, sts2 = st1.simplify(), st2.simplify()
+      stc1, stc2 = st1.canonicalize(), st2.canonicalize()
+      # compare results
       eq = st_equal(st1, st2)
-      if getenv("CHECK_NEQ") and eq and st1.simplify() != st2.simplify():
-        print(colored("same but unequal", "yellow"))
-        print(st1.simplify())
-        print(st2.simplify())
-        same_but_neq += 1
-      if DEBUG >= 1:
-        print(f"EXP: {st1}")
-        print(f"GOT: {st2}")
-        print(colored("****", "green" if eq else "red"))
+      eqs = sts1 == sts2
+      eqc = stc1 == stc2
+      # update stats
+      if getenv("CHECK_NEQ") and eq and not eqs: same_but_neq += 1
+      if eq and not eqc: same_but_neq_cannon += 1
+      # print stuff
+      filterout = False if DEBUG >=1 and getenv("ONLY_NEQ", 0)==0 else not (eq and not eqs)
+      if not filterout:
+        if eq and not eqc:
+          if DEBUG >=2 and getenv("VERBOSE", 1) == 2:
+            # extra stuff for printing
+            _display_extra_info(st1, st2)
+        if getenv("CHECK_NEQ") and eq and not eqs:
+          print(colored("same but unequal", "yellow"))
+          print(f"EXP SIMPL: {sts1}")
+          print(f"GOT SIMPL: {sts2}")
+        if DEBUG >=2:
+          print(f"EXP CANON: {stc1}")
+          print(f"GOT CANON: {stc2}")
+        if DEBUG >=1:
+          print(f"EXP: {st1}")
+          print(f"GOT: {st2}")
+        if DEBUG >=1:
+          print(colored(f"****{' (symbolic)' if DEBUG>=2 else ''}", "green" if eq else "red"))
+        if DEBUG >=2:
+          print(colored("**** (canon repr)", "green" if eqc else "red"))
+      # mandatory asserts
+      if eqs: assert eq and eqc, f"something is broken {eq=} {eqs=} {eqc=}"
       if not eq: exit(0)
-    if getenv("CHECK_NEQ"): print(f"same but unequal {(same_but_neq/total)*100:.2f}%")
+    # print agg stats
+    if getenv("CHECK_NEQ"):
+      print(f"same but unequal {(same_but_neq/total)*100:.2f}%")
+      if DEBUG >=2:
+        print(f"same but unequal cannon {(same_but_neq_cannon/total)*100:.2f}%")

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -101,8 +101,8 @@ if __name__ == "__main__":
         if DEBUG >=2:
           print(colored("**** (canon repr)", "green" if eqc else "red"))
       # mandatory asserts
-      if eqs: assert eq and eqc, f"something is broken {eq=} {eqs=} {eqc=}"
-      if not eq: exit(0)
+      if eqs: assert eq and eqc
+      if not (eq and eqc): exit(0)
     # print agg stats
     if getenv("CHECK_NEQ"):
       print(f"same but unequal {(same_but_neq/total)*100:.2f}%")

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         if DEBUG >=1:
           print(colored(f"****{' (symbolic)' if DEBUG>=2 else ''}", "green" if eq else "red"))
         if DEBUG >=2:
-          print(colored("**** (canon repr)", "green" if eqc else "red"))
+          print(colored("**** (canon)", "green" if eqc else "red"))
       # mandatory asserts
       if eqs: assert eq and eqc
       if not (eq and eqc): exit(0)

--- a/test/external/fuzz_shapetracker_math.py
+++ b/test/external/fuzz_shapetracker_math.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
           print(colored("**** (canon)", "green" if eqc else "red"))
       # mandatory asserts
       if eqs: assert eq and eqc
-      if not (eq and eqc): exit(0)
+      if not eq: exit(0)
     # print agg stats
     if getenv("CHECK_NEQ"):
       print(f"same but unequal {(same_but_neq/total)*100:.2f}%")

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -344,17 +344,17 @@ class TestZeroShapeTensor(unittest.TestCase):
     t = Tensor.rand(3, 2, 0)
     assert t.shape == (3, 2, 0)
     # numpy has stride 0, 0, 0; torch has stride 2, 1, 1
-    assert t.lazydata.st.real_strides() == (0, 0, 1)
+    assert t.lazydata.st.real_strides() == (0, 0, 0)
 
     t = Tensor.rand(3, 0, 2)
     assert t.shape == (3, 0, 2)
     # numpy has stride 0, 0, 0; torch has stride 2, 2, 1
-    assert t.lazydata.st.real_strides() == (0, 2, 1)
+    assert t.lazydata.st.real_strides() == (0, 0, 0)
 
     t = Tensor.rand(0, 0, 0)
     assert t.shape == (0, 0, 0)
     # numpy has stride 0, 0, 0; torch has stride 1, 1, 1
-    assert t.lazydata.st.real_strides() == (0, 0, 1)
+    assert t.lazydata.st.real_strides() == (0, 0, 0)
 
   def test_rand(self):
     t = Tensor.rand(3, 2, 0)

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -50,28 +50,30 @@ def _real_strides(vm2:View, vm1:View) -> Tuple[Optional[sint], ...]:
 @functools.lru_cache(maxsize=None)
 def merge_views(vm2:View, vm1:View, rigid:bool=True) -> Optional[View]:
   if vm2.contiguous: return vm1
-  if vm1.contiguous and vm1.shape == vm2.shape: return vm2
-  if not rigid and vm1.contiguous and vm1.size() == vm2.size(): return vm2
-  if vm1.contiguous and vm1.size() == vm2.size() and (ret := vm2.reshape(vm1.shape)) is not None: return ret
-  if not rigid and vm1.contiguous and vm1.size() != vm2.size() and vm2.offset == 0 and vm2.mask is None:
-    if (nshape := _fit_shape(vm2.shape, vm1.size())) is not None and len(nshape) == len(vm2.shape):
-      if prod(nshape) == vm1.size(): return View.create(nshape, vm2.strides, 0, None)
-  if not vm2.mask and vm1.offset == 0 and None not in (rstrides := ShapeTracker((vm2, vm1)).real_strides()):
-    return View.create(vm1.shape, cast(Tuple[sint, ...], rstrides), vm2.offset, vm1.mask)
+  if vm1.contiguous:
+    if vm1.shape == vm2.shape: return vm2
+    if vm1.size() == vm2.size():
+      if not rigid: return vm2
+      if (ret := vm2.reshape(vm1.shape)) is not None: return ret
+    if not rigid:
+      if not vm2.mask and vm2.offset == 0:
+        if (nshape := _fit_shape(vm2.shape, vm1.size())) is not None and len(nshape) == len(vm2.shape):
+          if prod(nshape) == vm1.size(): return View.create(nshape, vm2.strides, 0, None)
   if not rigid:
-    # TODO: handle cases where mask is there!
-    if not vm1.mask and vm1.strides == strides_for_shape(vm1.shape):# or (vm1.mask and vm1.strides == (1,)):
-      # first non-zero stride
-      idx = next(itr := iter(range(len(vm2.shape))))
-      lower = vm1.offset #+ (vm1.mask[idx][0] if vm1.mask else 0)
-      upper = vm1.offset + vm1.size() #+ (-vm1.mask[idx][1] if vm1.mask else 0)
+    vm1 = vm1.shrink(vm1.mask) if (backup := vm1).mask else vm1 # remove mask
+    if vm1.strides == strides_for_shape(vm1.shape):
+      lower = min(max(0, vm1.offset), vm2.size())
+      upper = min(max(0, vm1.offset + vm1.size()), vm2.size())
       if lower >= upper: return View.create(vm1.shape, (0,) * len(vm1.shape), 0, ((0,0),) * len(vm1.shape))
-      while vm2.strides[idx] == 0: idx = next(itr)
-      if 0 <= lower < upper and (stride := prod(vm2.shape[idx+1:])) != 0:
+      if 0 < len(vm2.shape) and 0 <= lower < upper and (stride := prod(vm2.shape[1:])) != 0:
         if lower % stride == 0 and upper % stride == 0:
           if (lb := lower // stride) <= vm2.shape[0] and (ub := upper // stride) <= vm2.shape[0]:
-            vm2_new = View.create(vm2.shape[idx:], vm2.strides[idx:], vm2.offset, vm2.mask[idx:] if vm2.mask else None)
-            return vm2_new.shrink(tuple((lb,ub) if i == 0 else (0,s) for i,s in enumerate(vm2.shape[idx:])))
+            vm2_new = View.create(vm2.shape, vm2.strides, vm2.offset, vm2.mask if vm2.mask else None)
+            arg = ((min(lb,vm2_new.shape[0]),min(ub,vm2_new.shape[0])),) + tuple((0,s) for s in vm2_new.shape[1:])
+            return vm2_new.shrink(arg)
+    vm1 = backup
+  if not vm2.mask and vm1.offset == 0 and None not in (rstrides := ShapeTracker((vm2, vm1)).real_strides()):
+    return View.create(vm1.shape, cast(Tuple[sint, ...], rstrides), vm2.offset, vm1.mask)
   if vm1.mask:
     for b,e in vm1.mask:
       if not (b < e): return View.create(vm1.shape, (0,) * len(vm1.shape), 0, ((0,0),) * len(vm1.shape))

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -238,7 +238,23 @@ class CanonicalShapeTracker(ShapeTracker):
   def __eq__(self, other):
     if not isinstance(other, CanonicalShapeTracker): return NotImplemented
     if self.views == other.views: return True
-    if len(self.views) == len(other.views) == 1:
-      st = ShapeTracker((self.views[0], other.views[0]) if self.size >= other.size else (other.views[0], self.views[0]))
-      if len(_canonicalize(st).views) == 1: return True
+    if len(self.views) == len(other.views) == 1 and len((a := self.views[0]).shape) == len((b := other.views[0]).shape) > 0:
+      if 0 not in a.strides and 0 not in b.strides:
+        arga, argb = [], []
+        for i in range(len(a.shape)):
+          if a.strides[i] == b.strides[i]:
+            arga.append(1)
+            argb.append(1)
+          elif a.strides[i] > b.strides[i]:
+            if a.strides[i] % b.strides[i] == 0:
+              arga.append(1)
+              argb.append(a.strides[i] // b.strides[i])
+            else: break
+          elif b.strides[i] > a.strides[i]:
+            if b.strides[i] % a.strides[i] == 0:
+              arga.append(b.strides[i] // a.strides[i])
+              argb.append(1)
+            else: break
+        else:
+          if a.stride(tuple(arga)) == b.stride(tuple(argb)): return True
     return False

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -149,14 +149,13 @@ class ShapeTracker:
     return ShapeTracker(cast(Tuple[View, ...], ret)).reshape(out_shape) if all(x is not None for x in ret) else None
 
   def _canonicalize(self) -> ShapeTracker:
-    ret = (self.shrink(mask) if (mask := self.views[-1].mask) else self).simplify(rigid=False)
-    if all(0<=st for st in ret.views[-1].strides): ret = ret.permute(argsort(ret.views[-1].strides)[::-1])
-    v = ret.views[-1]
+    v = (ret := (self.shrink(mask) if (mask := self.views[-1].mask) else self).simplify(rigid=False)).views[-1]
     zero_strided_dims = [i for i in range(len(v.shape)) if v.strides[i] == 0]
     shape = tuple(s for i,s in enumerate(v.shape) if i not in zero_strided_dims)
     strides = tuple(s for i,s in enumerate(v.strides) if i not in zero_strided_dims)
     mask = tuple(s for i,s in enumerate(v.mask) if i not in zero_strided_dims) if v.mask else None
     ret = ShapeTracker(ret.views[:-1] + (View.create(shape, strides, v.offset, mask),))
+    if all(0 <= st for st in ret.views[-1].strides): ret = ret.permute(argsort(ret.views[-1].strides)[::-1])
     return ShapeTracker(tuple(v.minify() for v in ret.views))
 
   def canonicalize(self) -> ShapeTracker:

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -156,16 +156,13 @@ class ShapeTracker:
     strides = tuple(s for i,s in enumerate(v.strides) if i not in zero_strided_dims)
     mask = tuple(s for i,s in enumerate(v.mask) if i not in zero_strided_dims) if v.mask else None
     ret = ShapeTracker(ret.views[:-1] if len(ret.views) > 1 else () + (View.create(shape, strides, v.offset, mask),))
-    if len(strides:=ret.views[-1].strides) > 0: ret = ret.stride(tuple(1 if 0<=st else -1 for st in ret.views[-1].strides))
     if len(strides:=ret.views[-1].strides) > 1 and not all(st==strides[0] for st in strides): ret = ret.permute(argsort(ret.views[-1].strides)[::-1])
     return ShapeTracker(tuple(v.minify() for v in ret.views))
 
   def canonicalize(self) -> ShapeTracker:
     ret = self._canonicalize()
     while ret != (nxt := ret._canonicalize()): ret = nxt
-    # normalize
-    ret = (ret.shrink(mask) if (mask := ret.views[-1].mask) else ret) # probably overkill
-    return ret.permute(argsort(sts)[::-1]) if len(sts:=ret.views[-1].strides) > 1 and not all(st==sts[0] for st in sts) else ret
+    return ret.permute(argsort(sts)[::-1]) if len(sts:=ret.views[-1].strides) > 1 and not all(st==sts[0] for st in sts[1:]) else ret
 
   @staticmethod
   def from_shape(shape:Tuple[sint, ...]) -> ShapeTracker: return ShapeTracker((View.create(shape),))

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -7,6 +7,7 @@ from tinygrad.shape.symbolic import Node, NumNode, Variable, sint
 
 @functools.lru_cache(maxsize=None)
 def canonicalize_strides(shape:Tuple[sint, ...], strides:Tuple[sint, ...]) -> Tuple[sint, ...]:
+  if any(s == 0 for s in shape): return (0,) * len(strides)
   return tuple(0 if s == 1 else st for s, st in zip(shape, strides))
 
 @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
bench:
```python
DEBUG=2 VERBOSE=2 SEED=6961 CNT=10000 CHECK_NEQ=1 ONLY_NEQ=1 FUZZ=plus PYTHONPATH="." python3 test/external/fuzz_shapetracker_math.py
```

baseline
```
same but unequal 5.41%
```

add rigid arg to merge_views and simplify
```
same but unequal 5.41%
same but unequal cannon 3.78%
```

_fix_shape for unequal size merging
```
same but unequal 5.41%
same but unequal cannon 3.77%
```

add lower bound for merging by shrink, fix merging condition in mergeviews
```
same but unequal 5.41%
same but unequal cannon 3.61%
```

add upper bound for merging by shrink
```
same but unequal 5.41%
same but unequal cannon 3.46%
```

recursively canonicalize shapetracker
```
same but unequal = 5.41%
same but unequal cannon = 2.51%
```

permute to fixed order
```
same but unequal = 5.41%
same but unequal cannon = 2.16%
```

remove zero strided dims
```
same but unequal = 5.41%
same but unequal cannon = 1.71%
```

refactor, fix conditions
```
same but unequal = 5.41%
same but unequal cannon = 1.19%
```

equals() makes a comeback
```
same but unequal = 5.41%
same but unequal cannon = 0.98%
```